### PR TITLE
Add rack-attack throttling capabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'lograge', '>= 0.11.2'
 # Geo coding
 gem 'geocoder'
 
+# Request throttling/blocking management
+gem 'rack-attack'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,8 @@ GEM
     public_suffix (4.0.3)
     puma (3.12.4)
     raabro (1.1.6)
+    rack-attack (6.2.2)
+      rack (>= 1.0, < 3)
     rack-mini-profiler (1.0.0)
       rack (>= 1.2.0)
     rack-protection (2.0.4)
@@ -412,6 +414,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.12)
   rack!
+  rack-attack
   rack-mini-profiler (~> 1.0)
   rails (~> 5.2.4.1)
   rqrcode

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,28 @@
+require 'redis'
+
+if ENV['cache_server_url']
+  redis = Redis.new(url: ENV['cache_server_url'])
+  Rack::Attack.cache.store = Rack::Attack::StoreProxy::RedisStoreProxy.new(redis)
+end
+
+# Enables throttling for auth requests to 10rpm
+Rack::Attack.throttle("auth requests per ip", limit: 10, period: 1.minute) do |req|
+  if ['/api/v1/callbacks/mobile_login', '/api/v1/callbacks/mobile_sign_up'].include?(req.path)
+    req.ip
+  end
+end
+
+# Enables throttling for non auth requests to 40rpm
+Rack::Attack.throttle("non auth requests per ip", limit: 40, period: 1.minute) do |req|
+  unless ['/api/v1/callbacks/mobile_login', '/api/v1/callbacks/mobile_sign_up'].include?(req.path)
+    req.ip
+  end
+end
+
+ActiveSupport::Notifications.subscribe('throttle.rack_attack') do |name, start, finish, request_id, payload|
+  req = payload[:request]
+
+  Rails.logger.info("[Rack::Attack][Blocked]" +
+                    "ip: \"#{req.ip}\"," +
+                    "path: \"#{req.path}\"")
+end


### PR DESCRIPTION
closes: https://github.com/solocoinapp/solocoin-backend/issues/49

*NOTE* this will use sidekiqs Redis backend for storing the counters/stats necessary for rack-attack to work. We should use a separate Redis instance for it.

/cc @prasadpilla 