### PR TITLE
Multiple redeem issue

### DIFF
--- a/app/controllers/api/v1/coin_codes_controller.rb
+++ b/app/controllers/api/v1/coin_codes_controller.rb
@@ -24,10 +24,12 @@ class Api::V1::CoinCodesController < Api::BaseController
     referral = Referral.find_by(code: params[:referral_coupon])
     amount = referral.amount || 500
     return render_error(:unprocessable_entity, 'Invalid Amount!') if amount.to_f <= 0
+    return render_error(:unprocessable_entity, 'Invalid Use Of Token!') if referral.user == referred_user
+    return render_error(:unprocessable_entity, 'Coupon Already Redeemed!') if referred_user.is_redeemed
     user_updated_balance = referral.user.wallet_balance.to_f + amount.to_f
     referral_user_updated_balance = referred_user.wallet_balance.to_f + amount.to_f
     referral.user.update(wallet_balance: user_updated_balance)
-    referred_user.update(wallet_balance: referral_user_updated_balance)
+    referred_user.update(wallet_balance: referral_user_updated_balance, is_redeemed: true)
     referral.update(
       referrals_count: referral.referrals_count + 1,
       referrals_amount: referral.referrals_amount + amount

--- a/app/controllers/api/v1/coin_codes_controller.rb
+++ b/app/controllers/api/v1/coin_codes_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::CoinCodesController < Api::BaseController
     coin_codes = current_user.coin_codes.blank? ? {} : current_user.coin_codes
     coin_codes["#{@coupon.id}"] = @coupon.coupon_code
     wallet_balance = current_user.wallet_balance.to_f + @coupon.amount.to_f
-    current_user.update(wallet_balance: wallet_balance, coin_codes: coin_codes)
+    current_user.update(wallet_balance: wallet_balance, coin_codes: coin_codes, total_earned_coins: total_earned_coins(current_user, @coupon.amount.to_f))
     limit = @coupon.limit - 1
     @coupon.update(limit: limit)
     render json: {success: true, message: "Successfully Redeemed!"}
@@ -28,8 +28,8 @@ class Api::V1::CoinCodesController < Api::BaseController
     return render_error(:unprocessable_entity, 'Coupon Already Redeemed!') if referred_user.is_redeemed
     user_updated_balance = referral.user.wallet_balance.to_f + amount.to_f
     referral_user_updated_balance = referred_user.wallet_balance.to_f + amount.to_f
-    referral.user.update(wallet_balance: user_updated_balance)
-    referred_user.update(wallet_balance: referral_user_updated_balance, is_redeemed: true)
+    referral.user.update(wallet_balance: user_updated_balance, total_earned_coins: total_earned_coins(referral.user, amount.to_f))
+    referred_user.update(wallet_balance: referral_user_updated_balance, is_redeemed: true, total_earned_coins: total_earned_coins(referred_user, amount.to_f))
     referral.update(
       referrals_count: referral.referrals_count + 1,
       referrals_amount: referral.referrals_amount + amount
@@ -49,4 +49,7 @@ class Api::V1::CoinCodesController < Api::BaseController
     end
   end
 
+  def total_earned_coins(user, amount)
+    user.total_earned_coins + amount
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -2,7 +2,7 @@ class Session < ApplicationRecord
   enum status: { 'in_progress': 0, done: 1 }
   enum session_type: { home: 0, away: 1 }
 
-  PING_TIMEOUT_IN_MINUTES = 30
+  PING_TIMEOUT_IN_MINUTES = 60
 
   belongs_to :user
 

--- a/db/migrate/20200908074518_add_is_redeemed_to_users.rb
+++ b/db/migrate/20200908074518_add_is_redeemed_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsRedeemedToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :is_redeemed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_21_074328) do
+ActiveRecord::Schema.define(version: 2020_09_08_074518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 2020_08_21_074328) do
     t.bigint "category_id"
     t.string "brand_logo"
     t.integer "reward_type", default: 0
+    t.string "currency_type", default: "$"
     t.index ["category_id"], name: "index_rewards_sponsors_on_category_id"
     t.index ["user_id"], name: "index_rewards_sponsors_on_user_id"
   end
@@ -204,6 +205,7 @@ ActiveRecord::Schema.define(version: 2020_08_21_074328) do
     t.string "designation"
     t.integer "total_earned_coins", default: 0
     t.jsonb "coin_codes"
+    t.boolean "is_redeemed", default: false
     t.index ["auth_token"], name: "index_users_on_auth_token"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email"


### PR DESCRIPTION
A. 1 a user can use his own referral code. thats definetely not desirable
A.2 no limit for referral code usage
A.3 is same of A.2 lol sorry
B some users saw an incremental increasein coins when they kept redeeming. Fixing A should probably fix these two because then they can only redeem once
C the user update Api accepts body but does not save the information to backend. for example giving the api home lat and long of the user is the primary use of this api. the users home location is not being uploaded in backend thru the user update api
D total coins are a record of all the coins the user has earned so far, this is how current milestone progress is decided. coins from the redeem social media coupons and referral code api's are not counted in total coins but only to wallet balance